### PR TITLE
Fit the city name into the box by adapting font size

### DIFF
--- a/certificate.js
+++ b/certificate.js
@@ -25,6 +25,17 @@ function getProfile() {
   return fields
 }
 
+function idealFontSize(font, text, maxWidth, minSize, defaultSize){
+  let currentSize = defaultSize;
+  let textWidth = font.widthOfTextAtSize(text, defaultSize);
+
+  while (textWidth > maxWidth && currentSize > minSize){
+    textWidth = font.widthOfTextAtSize(text, --currentSize);
+  }
+
+  return (textWidth > maxWidth) ? null : currentSize;
+}
+
 async function generatePdf(profile, reason) {
   const url = 'certificate.pdf'
   const existingPdfBytes = await fetch(url).then(res => res.arrayBuffer())
@@ -60,7 +71,15 @@ async function generatePdf(profile, reason) {
       break
   }
 
-  drawText(profile['done-at'] || profile.town, 375, 140)
+  let locationSize = idealFontSize(font, profile['done-at'] || profile.town, 83, 7, 11);
+
+  if (!locationSize){
+    alert('Le nom de la ville risque de ne pas etre affiché correctement en raison de sa longueur. ' +
+      'Essayez d\'utiliser des abréviations ("Saint" en "St." par exemple) quand cela est possible.');
+    locationSize = 7;
+  }
+
+  drawText(profile['done-at'] || profile.town, 375, 140, locationSize)
   drawText(String((new Date).getDate()), 478, 140)
   drawText(String((new Date).getMonth() + 1).padStart(2, '0'), 502, 140)
 


### PR DESCRIPTION
The PR brings a solution for the issue #8 by reducing font size dynamically when possible. 

Regarding the tests done, it can fit a city with a name length of ~23 characters, and will display a warning otherwise, suggesting the use of abbreviations.

## Possible improvments

- [] Dinamically replace patterns with abbreviations