### PR TITLE
Allow to generate forms without specifying a reason

### DIFF
--- a/certificate.js
+++ b/certificate.js
@@ -60,8 +60,10 @@ async function generatePdf(profile, reason) {
       break
   }
 
-  drawText(profile['done-at'] || profile.town, 375, 140)
-  drawText(String((new Date).getDate()), 478, 140)
+    drawText(profile['done-at'] || profile.town, 375, 140)
+    if (reason != '') {
+        drawText(String((new Date).getDate()), 478, 140)
+    }
   drawText(String((new Date).getMonth() + 1).padStart(2, '0'), 502, 140)
 
   const signatureArrayBuffer = await fetch(profile.signature).then(res => res.arrayBuffer())

--- a/index.html
+++ b/index.html
@@ -137,6 +137,11 @@
         <h5>Choisissez un motif de sortie</h5>
 
         <div class="form-check">
+            <input class="form-check-input" type="radio" name="field-reason" id="radio-none" value="" checked>
+            <label class="form-check-label" for="radio-none">Vide (il faudra cocher la cache et indiquer la date à la main)</label>
+        </div>
+
+        <div class="form-check">
             <input class="form-check-input" type="radio" name="field-reason" id="radio-work" value="work" checked>
             <label class="form-check-label" for="radio-work">Travail</label>
         </div>


### PR DESCRIPTION
This allows to generate pre-filled forms where you only have to manually check the appropriate box and indicate the date.
So you can print in advance a stock of them.